### PR TITLE
Fix incorrect https url

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -51,7 +51,6 @@ export const findRemoteUrl = (options: SpawnSyncOptions): string | Error => {
     ['remote', 'get-url', remotes[index]],
     options,
   ).stdout.toString().trim();
-
   if (url.startsWith(git)) {
     return convertToHttpsSchema(url);
   }

--- a/src/git.ts
+++ b/src/git.ts
@@ -62,5 +62,5 @@ export const convertToHttpsSchema = (url: string): string => {
   return url
     .replace(/^git@/, 'https://')
     .replace('github.com:', 'github.com/')
-    .replace(/.git$/, '');
+    .replace(/\.git$/, '');
 };

--- a/src/git.ts
+++ b/src/git.ts
@@ -50,7 +50,8 @@ export const findRemoteUrl = (options: SpawnSyncOptions): string | Error => {
     git,
     ['remote', 'get-url', remotes[index]],
     options,
-  ).stdout.toString();
+  ).stdout.toString().trim();
+
   if (url.startsWith(git)) {
     return convertToHttpsSchema(url);
   }


### PR DESCRIPTION
Hey, I notice that currently, `convertToHttpsSchema(url)` returns an invalid url.

`.replace(/.git$/, '')` is not being executed because there is a whitespace character at the end of the `url` variable. So, this regex expression is always false.To fix this, I've added `.trim()` to remove the whitespace character.

I've also fix the regex for replacing the `.git`. I think there should be `\` to escape the `.` 

Please review and merge. Thanks~ 🙏 


 